### PR TITLE
fix(font): use default font when error

### DIFF
--- a/converter.py
+++ b/converter.py
@@ -9,7 +9,18 @@ from requests import get
 
 from config import CONVERSION_CHARACTERS
 
-base_font = ImageFont.truetype("monos.ttf", 20)
+
+def load_font(
+    font_path: str, font_size: int
+) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
+    try:
+        return ImageFont.truetype(font_path, font_size)
+    except OSError:
+        # print(f"Load {font_path} font failed. Using default font.")
+        return ImageFont.load_default()
+
+
+base_font = load_font("monos.ttf", 20)
 
 
 def sizeof(text: str, font: ImageFont.FreeTypeFont = base_font) -> tuple[int, int]:


### PR DESCRIPTION
Thanks for your open-source code.

When I was using convert.py `image_to_ascii` to generate an `ascii`, I saw this error:
```
lib/python3.13/site-packages/PIL/ImageFont.py", 
line 284, in __init__ self.font = core.getfont( ~~~~~~~~~~~~^ 
font, size, index, encoding, layout_engine=layout_engine 

^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ )
```

I think it is related to this issue https://stackoverflow.com/questions/47694421/pil-issue-oserror-cannot-open-resource.

So I added the `load_font` function to load the default font when it failed to get `"monos.ttf"`.

Please take a look here. @ajratnam Thx again.